### PR TITLE
49/Web App: Head Section

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,34 +10,11 @@
       content="Web site created using create-react-app"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
-    <title>React App</title>
+    <title>Build Justly</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
   </body>
 </html>


### PR DESCRIPTION
Ticket Description
Fixes #49 

- [x] Head section currently reflects default React App, needs to be updated

Description of Changes
Just changed the react header to Build Justly text. (Will replace favicon with logo once we receive one, ticket is here: #54 )

Before and After for UI Updates:
Before:
![Screenshot 2022-11-30 at 3 01 57 PM](https://user-images.githubusercontent.com/59852686/204907294-66dc0ff6-e719-4bd3-9d2a-2e5dc12d584b.png)

After:
![Screenshot 2022-11-30 at 3 02 06 PM](https://user-images.githubusercontent.com/59852686/204907318-444509eb-d1a9-4106-b9c0-2fada5b8213a.png)


For PR Reviewer
 Does this file change the yarn.lock, package.json or package-lock.json file? If so, why?
 If this pr contains mobile and desktop changes, did you test on IphoneXr and desktop views?
 Does this file match the related tickets linked figma file, or does it pass the visual smell test?
 If this file contains javascript, does the javascript pass the smell test?
 If you don't feel super confident in your review, did you assign someone more senior to double check?
