### PR TITLE
Issue 47: Survey Confirmation Page Styling

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -57,9 +57,9 @@ function App() {
             <Route
               path='/success'
               element={
-                <RequireAuth>
+                // <RequireAuth>
                   <SuccessPage />
-                </RequireAuth>
+                // </RequireAuth>
               }
             />
 

--- a/src/App.js
+++ b/src/App.js
@@ -57,9 +57,9 @@ function App() {
             <Route
               path='/success'
               element={
-                // <RequireAuth>
+                <RequireAuth>
                   <SuccessPage />
-                // </RequireAuth>
+                </RequireAuth>
               }
             />
 

--- a/src/__tests__/components/pages/SuccessPage.test.jsx
+++ b/src/__tests__/components/pages/SuccessPage.test.jsx
@@ -4,5 +4,5 @@ import SuccessPage from 'components/pages/SuccessPage';
 
 it('renders success message', () => {
   render(<SuccessPage />);
-  expect(screen.getByText('Your survey has been submitted')).toBeInTheDocument();
+  expect(screen.getByText('Thank you for providing your data and helping us build the future of technology - for everyone.')).toBeInTheDocument();
 });

--- a/src/__tests__/components/pages/SuccessPage.test.jsx
+++ b/src/__tests__/components/pages/SuccessPage.test.jsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter as Router } from 'react-router-dom';
 import SuccessPage from 'components/pages/SuccessPage';
 
 it('renders success message', () => {
-  render(<SuccessPage />);
+  render(
+    <Router>
+      <SuccessPage />
+    </Router>
+  );
   expect(screen.getByText('Thank you for providing your data and helping us build the future of technology - for everyone.')).toBeInTheDocument();
 });

--- a/src/__tests__/components/pages/SuccessPage.test.jsx
+++ b/src/__tests__/components/pages/SuccessPage.test.jsx
@@ -4,5 +4,5 @@ import SuccessPage from 'components/pages/SuccessPage';
 
 it('renders success message', () => {
   render(<SuccessPage />);
-  expect(screen.getByText('Thank You!')).toBeInTheDocument();
+  expect(screen.getByText('Your survey has been submitted')).toBeInTheDocument();
 });

--- a/src/components/elements/HeroDesktop.jsx
+++ b/src/components/elements/HeroDesktop.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 export default function HeroDesktop() {
   return (
-      <section className='flex justify-between items-end h-48 mb-20 pb-5 pl-20 pr-32 bg-green-100'>
+      <section className='flex justify-between items-end h-48 pb-5 pl-20 pr-32 bg-green-100'>
         <h1 className='text-5xl text-white'>
           build <br/> 
           JUSTLY

--- a/src/components/pages/SuccessPage.jsx
+++ b/src/components/pages/SuccessPage.jsx
@@ -1,16 +1,23 @@
 
 function SuccessPage() {
   return (
-    <main className="px-8 md:px-40 pt-12 md:pt-0 text-center">
-      <div className="">
-        <h1 className='pb-7 md:pb-12 text-base md:text-3xl font-semibold'>
-          Thank you for providing your data and helping us build the future of technology - for everyone.
-        </h1>
-        <p>Your survey has been submitted</p>
-        <p>
-          Next, you should receive text message with instructions to open, download and install the Insights Agent
-        </p>
-      </div>
+    <main className="px-10 md:px-40 pt-12 md:pt-0 text-center">
+      <h1 className='pb-7 md:pb-12 text-base md:text-3xl font-semibold'>
+        Thank you for providing your data and helping us build the future of technology - for everyone.
+      </h1>
+
+      <ul className='pl-8 md:pl-14 pb-12 list-disc text-left space-y-8 '>
+        <li>
+          We are processing your information now and we’ll notify you with next steps.
+        </li>
+        <li>
+          You’ll receive a text message at the number you provided.
+        </li>
+        <li>
+          If you do not receive a message within 7 days, please send an email to tech4all@buildjustly.org and mention the Insights Agent.
+        </li>
+      </ul>
+
     </main>
   )
 }

--- a/src/components/pages/SuccessPage.jsx
+++ b/src/components/pages/SuccessPage.jsx
@@ -20,7 +20,7 @@ function SuccessPage() {
       </ul>
 
       <div>
-        <a href='https://buildjustly.org/' className='text-[#064187] underline md:no-underline md:hover:underline'>
+        <a href='https://buildjustly.org/' target="_blank" rel="noreferrer" className='text-[#064187] underline md:no-underline md:hover:underline'>
           Visit buildJUSTLY.org
         </a>
       </div>

--- a/src/components/pages/SuccessPage.jsx
+++ b/src/components/pages/SuccessPage.jsx
@@ -1,10 +1,11 @@
-import './SuccessPage.css'
 
 function SuccessPage() {
   return (
-    <main className="text-center">
-      <div className="container">
-        <h1>Thank You!</h1>
+    <main className="px-8 md:px-40 pt-12 md:pt-0 text-center">
+      <div className="">
+        <h1 className='pb-7 md:pb-12 text-base md:text-3xl font-semibold'>
+          Thank you for providing your data and helping us build the future of technology - for everyone.
+        </h1>
         <p>Your survey has been submitted</p>
         <p>
           Next, you should receive text message with instructions to open, download and install the Insights Agent

--- a/src/components/pages/SuccessPage.jsx
+++ b/src/components/pages/SuccessPage.jsx
@@ -25,7 +25,7 @@ function SuccessPage() {
         </a>
       </div>
       
-      <div className='hidden md:block float-right pt-5 text-xl underline'>
+      <div className='hidden md:block align-right pt-5 text-xl underline'>
         <Link to='/' className=''>Go back to Home</Link>
       </div>
 

--- a/src/components/pages/SuccessPage.jsx
+++ b/src/components/pages/SuccessPage.jsx
@@ -26,7 +26,7 @@ function SuccessPage() {
       </div>
       
       <div className='hidden md:block align-right pt-5 text-xl underline'>
-        <Link to='/' className=''>Go back to Home</Link>
+        <Link to='/'>Go back to Home</Link>
       </div>
 
     </main>

--- a/src/components/pages/SuccessPage.jsx
+++ b/src/components/pages/SuccessPage.jsx
@@ -18,6 +18,10 @@ function SuccessPage() {
         </li>
       </ul>
 
+      <a href='https://buildjustly.org/' className='text-[#064187] underline md:no-underline md:hover:underline'>
+        Visit buildJUSTLY.org
+      </a>
+
     </main>
   )
 }

--- a/src/components/pages/SuccessPage.jsx
+++ b/src/components/pages/SuccessPage.jsx
@@ -1,7 +1,8 @@
+import { Link } from 'react-router-dom'
 
 function SuccessPage() {
   return (
-    <main className="px-10 md:px-40 pt-12 md:pt-0 text-center">
+    <main className="px-10 md:px-40 xl:px-60 py-12 text-center">
       <h1 className='pb-7 md:pb-12 text-base md:text-3xl font-semibold'>
         Thank you for providing your data and helping us build the future of technology - for everyone.
       </h1>
@@ -18,9 +19,15 @@ function SuccessPage() {
         </li>
       </ul>
 
-      <a href='https://buildjustly.org/' className='text-[#064187] underline md:no-underline md:hover:underline'>
-        Visit buildJUSTLY.org
-      </a>
+      <div>
+        <a href='https://buildjustly.org/' className='text-[#064187] underline md:no-underline md:hover:underline'>
+          Visit buildJUSTLY.org
+        </a>
+      </div>
+      
+      <div className='hidden md:block float-right pt-5 text-xl underline'>
+        <Link to='/' className=''>Go back to Home</Link>
+      </div>
 
     </main>
   )


### PR DESCRIPTION
## Ticket Description
Confirmation page after survey should reflect [Figma](https://www.figma.com/file/saSl8LVUCEYpptPsvyGGHq/Insights-Agent?node-id=925%3A1021&t=vGDaOjtkl6UErvmO-0) link

- [x] Header
- [x] Bulletin points

Note: The progress bar has been listed as not high priority

## Description of Changes


## Before and After for UI Updates


### Before:
Desktop:
<img width="500" alt="image" src="https://user-images.githubusercontent.com/92892101/206236438-0d9d6af8-e7b9-4a60-83d5-d8793d682018.png">

Mobile:
<img width="494" alt="image" src="https://user-images.githubusercontent.com/92892101/206236744-ad97bbed-ae9c-48df-8fd5-14ee86ece8b5.png">


### After:

Desktop:
<img width="500" alt="image" src="https://user-images.githubusercontent.com/92892101/206282074-ba0c653d-163c-47cf-9ede-a82491afb4fd.png">


Mobile:
<img width="484" alt="image" src="https://user-images.githubusercontent.com/92892101/206281946-3c8f07f6-ee99-479e-a0a2-3a7540a3d1ed.png">


For PR Reviewer
 Does this file change the yarn.lock, package.json or package-lock.json file? If so, why?
 If this pr contains mobile and desktop changes, did you test on IphoneXr and desktop views?
 Does this file match the related tickets linked figma file, or does it pass the visual smell test?
 If this file contains javascript, does the javascript pass the smell test?
 If you don't feel super confident in your review, did you assign someone more senior to double check?
