### PR TITLE
71/Download Page Mobile View Banner

### DIFF
--- a/src/components/pages/DownloadPage.jsx
+++ b/src/components/pages/DownloadPage.jsx
@@ -8,9 +8,12 @@ import downloadButton from "../../images/download-arrow.svg";
 function DownloadPage() {
   return (
     <main>
+      <div className="visible md:hidden">
+        <HeroMobile />
+      </div>
       <h1 className="sr-only">Download Page</h1>
     
-      <section className="flex flex-col items-center mt-40">
+      <section className="hidden lg:flex flex-col items-center mt-40">
         <button className="hidden lg:flex p-4 rounded border-black border-2 bg-[#37770D] w-350">
           <img src={downloadButton} className="pr-4" alt="download image arrow pointing down" />
           <a className="text-white text-extrabold" href={DOWNLOAD_URL}>

--- a/src/components/pages/SurveyPage.jsx
+++ b/src/components/pages/SurveyPage.jsx
@@ -28,9 +28,6 @@ function SurveyForm({ touched, errors, values, setFieldValue, setValues }) {
     setValues(DEFAULT_FORM_VALUES);
   };
 
-  // TODO: Render errors. Logging here to help with debugging.
-  // console.log(errors);
-
   return (
     <Form className="flex flex-col lg:mx-40 md:mx-20 lg:place-items-center py-20 px-4">
       <div className=" bg-[#AECA9B] rounded">


### PR DESCRIPTION
## Ticket Description
Fixes #71 
Green banner was not showing for mobile view

## Description of Changes
Added banner for mobile in download page
Corrected spacing of hidden block 

## Before and After for UI Updates

Before:
Mobile:
<img width="500" alt="image" src="https://user-images.githubusercontent.com/92892101/207442089-2e283220-a214-4dde-a773-9054b14e085f.png">

Desktop:
<img width="500" alt="image" src="https://user-images.githubusercontent.com/92892101/207442186-c0c610c0-fbda-4350-9080-1b1ac1bb0caa.png">

After:
Mobile:
<img width="500" alt="image" src="https://user-images.githubusercontent.com/92892101/207442383-904494ae-3751-424d-bf09-250476d283ae.png">


Desktop:
<img width="500" alt="image" src="https://user-images.githubusercontent.com/92892101/207442313-e40b15d3-a77e-4d24-b345-4ba86ceb6655.png">


For PR Reviewer
 Does this file change the yarn.lock, package.json or package-lock.json file? If so, why?
 If this pr contains mobile and desktop changes, did you test on IphoneXr and desktop views?
 Does this file match the related tickets linked figma file, or does it pass the visual smell test?
 If this file contains javascript, does the javascript pass the smell test?
 If you don't feel super confident in your review, did you assign someone more senior to double check?
